### PR TITLE
C++20 Modules Support

### DIFF
--- a/dawn/webgpu.cppm
+++ b/dawn/webgpu.cppm
@@ -1,0 +1,2 @@
+#define WEBGPU_CPP_MODULE
+#include "webgpu.hpp"

--- a/dawn/webgpu.hpp
+++ b/dawn/webgpu.hpp
@@ -34,6 +34,16 @@
 
 #pragma once
 
+#ifdef WEBGPU_CPP_MODULE
+#define EXPORT export
+#else
+#define EXPORT
+#endif
+
+#ifdef WEBGPU_CPP_MODULE
+module;
+#endif
+
 #include <webgpu/webgpu.h>
 
 #include <iostream>
@@ -46,10 +56,14 @@
 #include <emscripten.h>
 #endif
 
+#ifdef WEBGPU_CPP_MODULE
+export module webgpu;
+#endif
+
 /**
  * A namespace providing a more C++ idiomatic API to WebGPU.
  */
-namespace wgpu {
+EXPORT namespace wgpu {
 
 struct DefaultFlag {};
 constexpr DefaultFlag Default;
@@ -1919,7 +1933,7 @@ END
 
 Instance createInstance(const InstanceDescriptor& descriptor);
 
-#ifdef WEBGPU_CPP_IMPLEMENTATION
+#if defined(WEBGPU_CPP_IMPLEMENTATION) || defined(WEBGPU_CPP_MODULE)
 
 Instance createInstance(const InstanceDescriptor& descriptor) {
 	return wgpuCreateInstance(&descriptor);
@@ -4078,12 +4092,13 @@ Device Adapter::requestDevice(const DeviceDescriptor& descriptor) {
 	return device;
 }
 
-#endif // WEBGPU_CPP_IMPLEMENTATION
+#endif // defined(WEBGPU_CPP_IMPLEMENTATION) || defined(WEBGPU_CPP_MODULE)
 
 #undef HANDLE
 #undef DESCRIPTOR
 #undef ENUM
 #undef ENUM_ENTRY
 #undef END
+#undef EXPORT
 
 } // namespace wgpu

--- a/dawn/webgpu.template.hpp
+++ b/dawn/webgpu.template.hpp
@@ -34,6 +34,16 @@
 
 #pragma once
 
+#ifdef WEBGPU_CPP_MODULE
+#define EXPORT export
+#else
+#define EXPORT
+#endif
+
+#ifdef WEBGPU_CPP_MODULE
+module;
+#endif
+
 #include <webgpu/webgpu.h>
 
 #include <iostream>
@@ -46,10 +56,14 @@
 #include <emscripten.h>
 #endif
 
+#ifdef WEBGPU_CPP_MODULE
+export module webgpu;
+#endif
+
 /**
  * A namespace providing a more C++ idiomatic API to WebGPU.
  */
-namespace wgpu {
+EXPORT namespace wgpu {
 
 struct DefaultFlag {};
 constexpr DefaultFlag Default;
@@ -167,7 +181,7 @@ wgpuDevicePopErrorScope
 
 Instance createInstance(const InstanceDescriptor& descriptor);
 
-#ifdef WEBGPU_CPP_IMPLEMENTATION
+#if defined(WEBGPU_CPP_IMPLEMENTATION) || defined(WEBGPU_CPP_MODULE)
 
 Instance createInstance(const InstanceDescriptor& descriptor) {
 	return wgpuCreateInstance(&descriptor);
@@ -227,12 +241,13 @@ Device Adapter::requestDevice(const DeviceDescriptor& descriptor) {
 	return device;
 }
 
-#endif // WEBGPU_CPP_IMPLEMENTATION
+#endif // defined(WEBGPU_CPP_IMPLEMENTATION) || defined(WEBGPU_CPP_MODULE)
 
 #undef HANDLE
 #undef DESCRIPTOR
 #undef ENUM
 #undef ENUM_ENTRY
 #undef END
+#undef EXPORT
 
 } // namespace wgpu

--- a/emscripten/webgpu.cppm
+++ b/emscripten/webgpu.cppm
@@ -1,0 +1,2 @@
+#define WEBGPU_CPP_MODULE
+#include "webgpu.hpp"

--- a/wgpu-native/webgpu.cppm
+++ b/wgpu-native/webgpu.cppm
@@ -1,0 +1,2 @@
+#define WEBGPU_CPP_MODULE
+#include "webgpu.hpp"

--- a/wgpu-native/webgpu.hpp
+++ b/wgpu-native/webgpu.hpp
@@ -34,6 +34,16 @@
 
 #pragma once
 
+#ifdef WEBGPU_CPP_MODULE
+#define EXPORT export
+#else
+#define EXPORT
+#endif
+
+#ifdef WEBGPU_CPP_MODULE
+module;
+#endif
+
 #include <webgpu/webgpu.h>
 #include <webgpu/wgpu.h>
 
@@ -47,10 +57,14 @@
 #include <emscripten.h>
 #endif
 
+#ifdef WEBGPU_CPP_MODULE
+export module webgpu;
+#endif
+
 /**
  * A namespace providing a more C++ idiomatic API to WebGPU.
  */
-namespace wgpu {
+EXPORT namespace wgpu {
 
 struct DefaultFlag {};
 constexpr DefaultFlag Default;
@@ -1398,7 +1412,7 @@ END
 
 Instance createInstance(const InstanceDescriptor& descriptor);
 
-#ifdef WEBGPU_CPP_IMPLEMENTATION
+#if defined(WEBGPU_CPP_IMPLEMENTATION) || defined(WEBGPU_CPP_MODULE)
 
 Instance createInstance(const InstanceDescriptor& descriptor) {
 	return wgpuCreateInstance(&descriptor);
@@ -2826,12 +2840,13 @@ Device Adapter::requestDevice(const DeviceDescriptor& descriptor) {
 	return device;
 }
 
-#endif // WEBGPU_CPP_IMPLEMENTATION
+#endif // defined(WEBGPU_CPP_IMPLEMENTATION) || defined(WEBGPU_CPP_MODULE)
 
 #undef HANDLE
 #undef DESCRIPTOR
 #undef ENUM
 #undef ENUM_ENTRY
 #undef END
+#undef EXPORT
 
 } // namespace wgpu

--- a/wgpu-native/webgpu.template.hpp
+++ b/wgpu-native/webgpu.template.hpp
@@ -34,6 +34,16 @@
 
 #pragma once
 
+#ifdef WEBGPU_CPP_MODULE
+#define EXPORT export
+#else
+#define EXPORT
+#endif
+
+#ifdef WEBGPU_CPP_MODULE
+module;
+#endif
+
 #include <webgpu/webgpu.h>
 #include <webgpu/wgpu.h>
 
@@ -47,10 +57,14 @@
 #include <emscripten.h>
 #endif
 
+#ifdef WEBGPU_CPP_MODULE
+export module webgpu;
+#endif
+
 /**
  * A namespace providing a more C++ idiomatic API to WebGPU.
  */
-namespace wgpu {
+EXPORT namespace wgpu {
 
 struct DefaultFlag {};
 constexpr DefaultFlag Default;
@@ -167,7 +181,7 @@ END
 
 Instance createInstance(const InstanceDescriptor& descriptor);
 
-#ifdef WEBGPU_CPP_IMPLEMENTATION
+#if defined(WEBGPU_CPP_IMPLEMENTATION) || defined(WEBGPU_CPP_MODULE)
 
 Instance createInstance(const InstanceDescriptor& descriptor) {
 	return wgpuCreateInstance(&descriptor);
@@ -227,12 +241,13 @@ Device Adapter::requestDevice(const DeviceDescriptor& descriptor) {
 	return device;
 }
 
-#endif // WEBGPU_CPP_IMPLEMENTATION
+#endif // defined(WEBGPU_CPP_IMPLEMENTATION) || defined(WEBGPU_CPP_MODULE)
 
 #undef HANDLE
 #undef DESCRIPTOR
 #undef ENUM
 #undef ENUM_ENTRY
 #undef END
+#undef EXPORT
 
 } // namespace wgpu


### PR DESCRIPTION
Hi! Thanks for the project :) I've made a PR adding support for C++20 modules. In this implementation, module's source is `#ifdef`ed inside the `webgpu.hpp` file. The `webgpu.cppm` module file simply defines `WEBGPU_CPP_MODULE` and includes `webgpu.hpp`.

This is how the header looks normally:

```c++
#include <webgpu.h>
// other includes

namespace wgpu {
// defines
#ifdef WEBGPU_CPP_IMPLEMENTATION
// implementation
#endif
}
```

And this is how the header looks when the `WEBGPU_CPP_MODULE` is defined. This is intended to be compiled as a standalone header unit:

```c++
module;

#include <webgpu.h>
// other includes

export module webgpu;

export namespace wgpu {
// defines
// implementation
}
```