### PR TITLE
Make enum types literal and structural

### DIFF
--- a/dawn/webgpu.hpp
+++ b/dawn/webgpu.hpp
@@ -128,7 +128,7 @@ public: \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
-	W m_raw;
+	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)Value;

--- a/dawn/webgpu.hpp
+++ b/dawn/webgpu.hpp
@@ -126,11 +126,9 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
-	Type(const W& w) : m_raw(w) {} \
-	operator W() const { return m_raw; } \
-private: \
-	W m_raw; \
-public:
+	constexpr Type(const W& w) : m_raw(w) {} \
+	constexpr operator W() const { return m_raw; } \
+	W m_raw;
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)Value;

--- a/dawn/webgpu.template.hpp
+++ b/dawn/webgpu.template.hpp
@@ -128,7 +128,7 @@ public: \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
-	W m_raw;
+	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)Value;

--- a/dawn/webgpu.template.hpp
+++ b/dawn/webgpu.template.hpp
@@ -126,11 +126,9 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
-	Type(const W& w) : m_raw(w) {} \
-	operator W() const { return m_raw; } \
-private: \
-	W m_raw; \
-public:
+	constexpr Type(const W& w) : m_raw(w) {} \
+	constexpr operator W() const { return m_raw; } \
+	W m_raw;
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)Value;

--- a/emscripten/webgpu.hpp
+++ b/emscripten/webgpu.hpp
@@ -127,7 +127,7 @@ public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
 	Type(const W& w) : m_raw(w) {} \
-	operator W() { return m_raw; } \
+	operator W() const { return m_raw; } \
 private: \
 	W m_raw; \
 public:

--- a/emscripten/webgpu.hpp
+++ b/emscripten/webgpu.hpp
@@ -128,7 +128,7 @@ public: \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
-	W m_raw;
+	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)Value;

--- a/emscripten/webgpu.hpp
+++ b/emscripten/webgpu.hpp
@@ -126,11 +126,9 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
-	Type(const W& w) : m_raw(w) {} \
-	operator W() const { return m_raw; } \
-private: \
-	W m_raw; \
-public:
+	constexpr Type(const W& w) : m_raw(w) {} \
+	constexpr operator W() const { return m_raw; } \
+	W m_raw;
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)Value;

--- a/emscripten/webgpu.template.hpp
+++ b/emscripten/webgpu.template.hpp
@@ -127,7 +127,7 @@ public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
 	Type(const W& w) : m_raw(w) {} \
-	operator W() { return m_raw; } \
+	operator W() const { return m_raw; } \
 private: \
 	W m_raw; \
 public:

--- a/emscripten/webgpu.template.hpp
+++ b/emscripten/webgpu.template.hpp
@@ -128,7 +128,7 @@ public: \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
-	W m_raw;
+	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)Value;

--- a/emscripten/webgpu.template.hpp
+++ b/emscripten/webgpu.template.hpp
@@ -126,11 +126,9 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
-	Type(const W& w) : m_raw(w) {} \
-	operator W() const { return m_raw; } \
-private: \
-	W m_raw; \
-public:
+	constexpr Type(const W& w) : m_raw(w) {} \
+	constexpr operator W() const { return m_raw; } \
+	W m_raw;
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)Value;

--- a/wgpu-native/webgpu.hpp
+++ b/wgpu-native/webgpu.hpp
@@ -129,7 +129,7 @@ public: \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
-	W m_raw;
+	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)(Value);

--- a/wgpu-native/webgpu.hpp
+++ b/wgpu-native/webgpu.hpp
@@ -127,11 +127,9 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
-	Type(const W& w) : m_raw(w) {} \
-	operator W() const { return m_raw; } \
-private: \
-	W m_raw; \
-public:
+	constexpr Type(const W& w) : m_raw(w) {} \
+	constexpr operator W() const { return m_raw; } \
+	W m_raw;
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)(Value);

--- a/wgpu-native/webgpu.template.hpp
+++ b/wgpu-native/webgpu.template.hpp
@@ -129,7 +129,7 @@ public: \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
-	W m_raw;
+	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)(Value);

--- a/wgpu-native/webgpu.template.hpp
+++ b/wgpu-native/webgpu.template.hpp
@@ -127,11 +127,9 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
-	Type(const W& w) : m_raw(w) {} \
-	operator W() const { return m_raw; } \
-private: \
-	W m_raw; \
-public:
+	constexpr Type(const W& w) : m_raw(w) {} \
+	constexpr operator W() const { return m_raw; } \
+	W m_raw;
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)(Value);


### PR DESCRIPTION
I should mention that I'm a bit of a C++ newbie, so this change may have undesirable consequences I'm not yet aware of.

## Commit 1 

The first commit in this PR changes the emscripten enum types to be defined the same way as on other platforms. I'm not sure why they were different, but the macro that defines the enum types for emscripten were defined like this:

```C++
#define ENUM(Type) \
class Type { \
public: \
	typedef Type S; /* S == Self */ \
	typedef WGPU ## Type W; /* W == WGPU Type */ \
	Type(const W& w) : m_raw(w) {} \
	operator W() { return m_raw; } \
private: \
	W m_raw; \
public:
```

While the other types were defined like this:

```C++
#define ENUM(Type) \
class Type { \
public: \
	typedef Type S; /* S == Self */ \
	typedef WGPU ## Type W; /* W == WGPU Type */ \
	Type(const W& w) : m_raw(w) {} \
	operator W() const { return m_raw; } \ // ← Note the addition of `const`
private: \
	W m_raw; \
public:
```

I thought this could have been just an oversight so I corrected it.

## Commit 2

### literal

I was having fun with templates and tried creating this:

```C++
template <uint32_t BindingIndex, wgpu::ShaderStage Visibility, wgpu::TextureSampleType SampleType,
          wgpu::TextureViewDimension ViewDimension, bool Multisampled = false>
struct TextureBinding {
   static constexpr uint32_t                   binding       = BindingIndex;
   static constexpr wgpu::ShaderStage          visibility    = Visibility;
   static constexpr wgpu::TextureSampleType    sampleType    = SampleType;
   static constexpr wgpu::TextureViewDimension viewDimension = ViewDimension;
   static constexpr bool                       multisampled  = Multisampled;
};
```

However this results in an error for each of the `wgpu::` types. The error is that says that `wgpu::` types cannot be used in this way because they are non-literal:

```
error: constexpr variable cannot have non-literal type 'const wgpu::TextureViewDimension'
note: 'TextureViewDimension' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
```

It's notable that this only applies to the wrappers from `webgpu.hpp`. **If you were instead to use the base types from `webgpu.h`, it compiles without issue.** So I modified the macro so that the functions it creates are constexpr.

### structural

Unfortunately, doing the above reveals a second error. The error is that `wgpu::` types cannot be used in this way because they are non-structural:

```
error: type 'wgpu::TextureViewDimension' of non-type template parameter is not a structural type
note: 'wgpu::TextureViewDimension' is not a structural type because it has a non-static data member that is not public
```

The only data member that I could see was `m_raw`, so I made it public, and then my example above compiled!

As I said before, I'm a C++ newbie, so I can't say I fully understand the consequences of making it public. You could no longer rename it without breaking backwards compatibility, but the underlying implementations break backwards compatibility all the time. It also means users could modify m_raw, but I don't know if that would be bad. If so, perhaps it could be made `const`?
