### PR TITLE
Make enum types default constructible

### DIFF
--- a/dawn/webgpu.hpp
+++ b/dawn/webgpu.hpp
@@ -126,6 +126,7 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
+	constexpr Type() : m_raw(W{}) {} /* Using default value-initialization */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
 	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */

--- a/dawn/webgpu.template.hpp
+++ b/dawn/webgpu.template.hpp
@@ -126,6 +126,7 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
+	constexpr Type() : m_raw(W{}) {} /* Using default value-initialization */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
 	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */

--- a/emscripten/webgpu.hpp
+++ b/emscripten/webgpu.hpp
@@ -126,6 +126,7 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
+	constexpr Type() : m_raw(W{}) {} /* Using default value-initialization */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
 	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */

--- a/emscripten/webgpu.template.hpp
+++ b/emscripten/webgpu.template.hpp
@@ -126,6 +126,7 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
+	constexpr Type() : m_raw(W{}) {} /* Using default value-initialization */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
 	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */

--- a/wgpu-native/webgpu.hpp
+++ b/wgpu-native/webgpu.hpp
@@ -127,6 +127,7 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
+	constexpr Type() : m_raw(W{}) {} /* Using default value-initialization */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
 	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */

--- a/wgpu-native/webgpu.template.hpp
+++ b/wgpu-native/webgpu.template.hpp
@@ -127,6 +127,7 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
+	constexpr Type() : m_raw(W{}) {} /* Using default value-initialization */ \
 	constexpr Type(const W& w) : m_raw(w) {} \
 	constexpr operator W() const { return m_raw; } \
 	const W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. */


### PR DESCRIPTION
Trying to build converted tutorial's code, `.resize` caused error `no appropriate default constructor available` (MSVC):
```cpp
    std::vector<wgpu::FeatureName> features{};
    size_t featuresCount = adapter.enumerateFeatures(nullptr);
    features.resize(featuresCount);
    adapter.enumerateFeatures(features.data());
```
Managed to fix it by adding this to my copy of ENUM define:
```cpp
Type() : m_raw(W{}) {} \
```
So created a pull request by looking at the previous one and slightly improving my fix.

Checked enums default value-initialization behaviour, so this pull request should make them more similar to it
![image](https://github.com/user-attachments/assets/042e9666-8ab0-4526-9001-586e20a533eb)
There can be arguments that wgpu enums would be more type-safe without a default constructor, but I think that, as long as functions like `classInstance.enumerateSomething(ptr)` are being used, it is better to have it