### PR TITLE
Allow createInstance to accept no args

### DIFF
--- a/emscripten/webgpu.template.hpp
+++ b/emscripten/webgpu.template.hpp
@@ -181,9 +181,14 @@ END
 // Non-member procedures
 {{procedures}}
 
+Instance createInstance();
 Instance createInstance(const InstanceDescriptor& descriptor);
 
 #ifdef WEBGPU_CPP_IMPLEMENTATION
+
+Instance createInstance() {
+	return wgpuCreateInstance(nullptr);
+}
 
 Instance createInstance(const InstanceDescriptor& descriptor) {
 	return wgpuCreateInstance(&descriptor);


### PR DESCRIPTION
Add an override of createInstance that accepts no arguments, in which case it passes `nullptr` to `wgpuCreateInstance`.

This is useful for the current version of Emscripten, which expects `wgpuCreateInstance` to always be passed with `nullptr` (see https://github.com/emscripten-core/emscripten/blob/585924b655cf0a064bb8729e18e0cf1534d90636/system/lib/webgpu/webgpu.cpp#L24).